### PR TITLE
Fix lifecycle selection

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,16 +10,24 @@ const serviceResponse = await client.queries.serviceConnection();
 // @ts-ignore
 const serviceEdges: ServiceConnectionEdges[] = serviceResponse.data.serviceConnection.edges || [];
 
+const now = new Date();
+
 const services = serviceEdges.map((service: ServiceConnectionEdges) => {
   const lifecycle = service.node?.lifecycle || [];
-  const length: number = lifecycle?.length || 0;
+
+  // Find the most recent lifecycle entry that is NOT in the future
+  const currentLifecycle = lifecycle
+    .filter(entry => new Date(entry.date) <= now)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())[0];
+
+  const status = currentLifecycle?.state || "unknown";
   const productOwner = service.node?.product_owner?.name;
   const dateString: string = formatDate(service.node?.last_updated)
 
   return {
     id: service.node?.id,
     name: service.node?.name,
-    status: lifecycle[length - 1]?.state,
+    status: status,
     product_owner: productOwner,
     criticality: service.node?.criticality,
     lastUpdated: dateString


### PR DESCRIPTION
Before this PR always the last `lifecycle` entry in the `content/service/<name>.yml ` definition file was used to display the status badge in the list view.
After this PR the currently valid lifecycle entry is taken based on the current date and the date given for the lifecycles in the definition file.

### Example
Today: 06.09.2025

Content in the definiton file:
```
lifecycle:
  - state: in_production
    date: 2023-09-30
  - state: in_progress
    date: 2020-11-13
  - state: planned
    date: 2026-01-01
```

Before this PR: `planned`
After this PR: `in_production`