### PR TITLE
Format date only once

### DIFF
--- a/src/pages/services/[name].astro
+++ b/src/pages/services/[name].astro
@@ -196,7 +196,7 @@ const lastUpdatedValue: string = formatDate(service?.last_updated)
               lifecycles.map((lifecycle) => {
                 return (
                   <li>
-                    {formatDate(lifecycle!.date)}:{" "}
+                    {lifecycle!.date}:{" "}
                     <span class:list={['px-1.5', 'py-0.5', 'rounded', 'text-xs', 
                               getBgColorByStatus(lifecycle?.state)]}>
                               {lifecycle?.state}


### PR DESCRIPTION
Before this PR, dates in the single item view of services show `Invalid Date` in the lifecycle section.
After this PR the date formatted to the local date string "de-CH" is shown.

**What was the issue?**
The issue was that the date was reformatted twice. First time it is reformatted using in a loop where all lifecycle objects are reformetted using `new Date(life.date).toLocaleDateString("de-CH")`.
Afterwards is was again reformatted using `formatDate()`. The second reformatting failed as the date is not a ISO-String anymore.
To solve that the PR removes the second reformatting in the layout section.