### PR TITLE
Optimize CSS of views

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -62,7 +62,7 @@ export default function Search(props: Props) {
                             <td>Status</td>
                             <td>Cirticality</td>
                             <td>Product Owner</td>
-                            <td>last updated</td>
+                            <td>Last Updated</td>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -31,7 +31,7 @@ export default function Search(props: Props) {
             <input
                 type="text"
                 placeholder="Search..."
-                className="border border-gray-300 rounded p-2 w-full"
+                className="border border-gray-300 rounded p-2 w-full mb-4"
                 value={search}
                 onChange={(e) => {
                     setSearch(e.target.value)

--- a/src/pages/buckets/[variant].astro
+++ b/src/pages/buckets/[variant].astro
@@ -100,14 +100,14 @@ const bucketKeys = Object.keys(buckets).sort((a, b) => {
       </div>
     </div>
 
-    <div class="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+    <div class="grid grid-cols-1 gap-2 lg:grid-cols-2">
       {
         bucketKeys.map((bucket) => (
           <div class="rounded-lg bg-white p-1 shadow-md" id={bucket}>
             <h2 class="mt-1 ml-2 mb-4 text-2xl font-bold">
               {beautifyString(bucket)}
             </h2>
-            <table cellpadding="7" class="table-auto">
+            <table cellpadding="7" class="table-auto w-full">
               <thead
                 style={{
                   fontWeight: "bolder",

--- a/src/pages/parties/[key].astro
+++ b/src/pages/parties/[key].astro
@@ -18,11 +18,8 @@ const party: Party = Astro.props.party;
 
 <Layout title={party.name}>
   <main class="container mx-auto py-10">
-    <button
-      class="text-brombeer underline hover:font-medium"
-      onclick="history.back()"
-    >
-      back
+    <button class="btn" onclick="history.back()">
+      Back
     </button>
     <article class="bg-white shadow-md rounded-xl p-10 max-w-4xl mx-auto">
       <h1 class="text-5xl font-extrabold">{party.name}</h1>

--- a/src/pages/services/[name].astro
+++ b/src/pages/services/[name].astro
@@ -80,8 +80,8 @@ const lastUpdatedValue: string = formatDate(service?.last_updated)
       back
     </button>
     <article class="bg-white shadow-md rounded-xl p-10 max-w-4xl mx-auto">
-      <h1 class="text-5xl font-extrabold">{service?.name}</h1>
-      <span class="block text-sm mb-3"
+      <h1 class="text-5xl font-extrabold mb-3">{service?.name}</h1>
+      <span class="block text-sm mb-4"
         >Last Updated: {lastUpdatedValue}</span
       >
       <TinaMarkdown content={service?.description}/>

--- a/src/pages/services/[name].astro
+++ b/src/pages/services/[name].astro
@@ -76,8 +76,8 @@ const lastUpdatedValue: string = formatDate(service?.last_updated)
 
 <Layout title={service?.name || ""}>
   <main class="container mx-auto py-10">
-    <button class="text-brombeer underline hover:font-medium" onclick="history.back()">
-      back
+    <button class="btn" onclick="history.back()">
+      Back
     </button>
     <article class="bg-white shadow-md rounded-xl p-10 max-w-4xl mx-auto">
       <h1 class="text-5xl font-extrabold mb-3">{service?.name}</h1>
@@ -209,8 +209,8 @@ const lastUpdatedValue: string = formatDate(service?.last_updated)
         </dd>
       </dl>
     </article>
-    <button class="text-brombeer underline hover:font-medium" onclick="history.back()">
-      back
+    <button class="btn" onclick="history.back()">
+      Back
     </button>
   </main>
 </Layout>

--- a/tailwind.config.css
+++ b/tailwind.config.css
@@ -3,5 +3,10 @@
 @theme {
   --color-brombeer: #521d3a;
   --color-brombeer-200: #521d3a33;
+  --color-brombeer-300: #802f5b;
   --color-gray: #f8f7f6;
+}
+
+.btn {
+  @apply px-4 py-2 rounded bg-brombeer text-white cursor-pointer hover:bg-brombeer-300;
 }


### PR DESCRIPTION
Following changes:

**Bucket View**
In the Bucket View was not properly displayed on small screens. This PR optimizes the display down to displey sizes of a width of 470px. Devices with a display smaller than 470px will still have display problems due to the use of tables in the template.

**Services View**
Added some margin between title and suptitle. Adjust menu titles.